### PR TITLE
Fix typings for CommandObject callback

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -101,7 +101,7 @@ export interface CommandUsage {
 }
 
 export interface CommandObject {
-  callback: function
+  callback: (commandUsage: CommandUsage) => unknown
   type: CommandType
   init?: function
   description?: string


### PR DESCRIPTION
No more manually type casting CommandUsage

```ts
export default {
	callback: ({ }) => {}
	//          ^ Autocomplete here

} as CommandObject
```