### PR TITLE
fix: command permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "wokcommands",
       "version": "2.0.3",
       "license": "ISC",
       "dependencies": {

--- a/src/command-handler/commands/channelcommand.ts
+++ b/src/command-handler/commands/channelcommand.ts
@@ -1,96 +1,84 @@
-import { ApplicationCommandOptionType, CommandInteraction, PermissionFlagsBits } from "discord.js";
+import { ApplicationCommandOptionType, ChannelType, CommandInteraction, PermissionFlagsBits } from "discord.js";
 
 import Command from "../Command";
 import CommandType from "../../util/CommandType";
 import { CommandObject, CommandUsage } from "../../../typings";
 
 export default {
-  description: "Specifies what commands can be ran inside of what channels",
+	description: "Specifies what commands can be ran inside of what channels",
 
-  type: CommandType.SLASH,
-  guildOnly: true,
-  permissions: [PermissionFlagsBits.Administrator],
+	type: CommandType.SLASH,
+	guildOnly: true,
+	permissions: [PermissionFlagsBits.Administrator],
 
-  options: [
-    {
-      name: "command",
-      description: "The command to restrict to specific channels",
-      required: true,
-      type: ApplicationCommandOptionType.String,
-      autocomplete: true,
-    },
-    {
-      name: "channel",
-      description: "The channel to use for this command",
-      required: true,
-      type: ApplicationCommandOptionType.Channel,
-    },
-  ],
+	options: [
+		{
+			name: "command",
+			description: "The command to restrict to specific channels",
+			required: true,
+			type: ApplicationCommandOptionType.String,
+			autocomplete: true,
+		},
+		{
+			name: "channel",
+			description: "The channel to use for this command",
+			required: true,
+			type: ApplicationCommandOptionType.Channel,
+			channelTypes: [ChannelType.GuildText],
+		},
+	],
 
-  autocomplete: (command: Command) => {
-    return [...command.instance.commandHandler.commands.keys()];
-  },
+	autocomplete: (command: Command) => {
+		return [...command.instance.commandHandler.commands.keys()];
+	},
 
-  callback: async (commandUsage: CommandUsage) => {
-    const { instance, guild } = commandUsage;
+	callback: async (commandUsage: CommandUsage) => {
+		const { instance, guild } = commandUsage;
 
-    if (!instance.isConnectedToDB) {
-      return {
-        content:
-          "This bot is not connected to a database which is required for this command. Please contact the bot owner.",
-        ephemeral: true,
-      };
-    }
+		if (!instance.isConnectedToDB) {
+			return {
+				content: "This bot is not connected to a database which is required for this command. Please contact the bot owner.",
+				ephemeral: true,
+			};
+		}
 
-    const interaction: CommandInteraction = commandUsage.interaction!;
+		const interaction: CommandInteraction = commandUsage.interaction!;
 
-    // @ts-ignore
-    const commandName = interaction.options.getString("command");
-    // @ts-ignore
-    const channel = interaction.options.getChannel("channel");
+		// @ts-ignore
+		const commandName = interaction.options.getString("command");
+		// @ts-ignore
+		const channel = interaction.options.getChannel("channel");
 
-    const command = instance.commandHandler.commands.get(
-      commandName.toLowerCase()
-    );
-    if (!command) {
-      return {
-        content: `The command "${commandName}" does not exist.`,
-        ephemeral: true,
-      };
-    }
+		const command = instance.commandHandler.commands.get(commandName.toLowerCase());
+		if (!command) {
+			return {
+				content: `The command "${commandName}" does not exist.`,
+				ephemeral: true,
+			};
+		}
 
-    const { channelCommands } = instance.commandHandler;
+		const { channelCommands } = instance.commandHandler;
 
-    let availableChannels = [];
-    const canRun = (
-      await channelCommands.getAvailableChannels(guild!.id, commandName)
-    ).includes(channel.id);
+		let availableChannels = [];
+		const canRun = (await channelCommands.getAvailableChannels(guild!.id, commandName)).includes(channel.id);
 
-    if (canRun) {
-      availableChannels = await channelCommands.remove(
-        guild!.id,
-        commandName,
-        channel.id
-      );
-    } else {
-      availableChannels = await channelCommands.add(
-        guild!.id,
-        commandName,
-        channel.id
-      );
-    }
+		if (canRun) {
+			availableChannels = await channelCommands.remove(guild!.id, commandName, channel.id);
+		} else {
+			availableChannels = await channelCommands.add(guild!.id, commandName, channel.id);
+		}
 
-    if (availableChannels.length) {
-      const channelNames = availableChannels.map((c: string) => `<#${c}> `);
-      return {
-        content: `The command "${commandName}" can now only be ran inside of the following channels: ${channelNames}`,
-        ephemeral: true,
-      };
-    }
+		if (availableChannels.length) {
+			const channelNames = availableChannels.map((c: string) => `<#${c}> `);
+			return {
+				content: `The command "${commandName}" can now only be ran inside of the following channels: ${channelNames}`,
+				ephemeral: true,
+			};
+		}
 
-    return {
-      content: `The command "${commandName}" can now be ran inside of any text channel.`,
-      ephemeral: true,
-    };
-  },
+		return {
+			content: `The command "${commandName}" can now be ran inside of any text channel.`,
+			ephemeral: true,
+		};
+	},
 } as CommandObject;

--- a/src/command-handler/commands/channelcommand.ts
+++ b/src/command-handler/commands/channelcommand.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType, CommandInteraction } from "discord.js";
+import { ApplicationCommandOptionType, CommandInteraction, PermissionFlagsBits } from "discord.js";
 
 import Command from "../Command";
 import CommandType from "../../util/CommandType";
@@ -9,6 +9,7 @@ export default {
 
   type: CommandType.SLASH,
   guildOnly: true,
+  permissions: [PermissionFlagsBits.Administrator],
 
   options: [
     {

--- a/src/command-handler/commands/requiredroles.ts
+++ b/src/command-handler/commands/requiredroles.ts
@@ -6,123 +6,119 @@ import { CommandObject, CommandUsage } from "../../../typings";
 import Command from "../Command";
 
 export default {
-  description: "Sets what commands require what roles",
+	description: "Sets what commands require what roles",
 
-  type: CommandType.SLASH,
-  guildOnly: true,
+	type: CommandType.SLASH,
+	guildOnly: true,
 
-  roles: [PermissionFlagsBits.Administrator],
+	permissions: [PermissionFlagsBits.Administrator],
 
-  options: [
-    {
-      name: "command",
-      description: "The command to set roles to",
-      type: ApplicationCommandOptionType.String,
-      required: true,
-      autocomplete: true,
-    },
-    {
-      name: "role",
-      description: "The role to set for the command",
-      type: ApplicationCommandOptionType.Role,
-      required: false,
-    },
-  ],
+	options: [
+		{
+			name: "command",
+			description: "The command to set roles to",
+			type: ApplicationCommandOptionType.String,
+			required: true,
+			autocomplete: true,
+		},
+		{
+			name: "role",
+			description: "The role to set for the command",
+			type: ApplicationCommandOptionType.Role,
+			required: false,
+		},
+	],
 
-  autocomplete: (command: Command) => {
-    return [...command.instance.commandHandler.commands.keys()];
-  },
+	autocomplete: (command: Command) => {
+		return [...command.instance.commandHandler.commands.keys()];
+	},
 
-  callback: async (commandUsage: CommandUsage) => {
-    const { instance, guild, args } = commandUsage;
+	callback: async (commandUsage: CommandUsage) => {
+		const { instance, guild, args } = commandUsage;
 
-    if (!instance.isConnectedToDB) {
-      return {
-        content:
-          "This bot is not connected to a database which is required for this command. Please contact the bot owner.",
-        ephemeral: true,
-      };
-    }
+		if (!instance.isConnectedToDB) {
+			return {
+				content: "This bot is not connected to a database which is required for this command. Please contact the bot owner.",
+				ephemeral: true,
+			};
+		}
 
-    const [commandName, role] = args;
+		const [commandName, role] = args;
 
-    const command = instance.commandHandler.commands.get(commandName);
-    if (!command) {
-      return {
-        content: `The command "${commandName}" does not exist.`,
-        ephemeral: true,
-      };
-    }
+		const command = instance.commandHandler.commands.get(commandName);
+		if (!command) {
+			return {
+				content: `The command "${commandName}" does not exist.`,
+				ephemeral: true,
+			};
+		}
 
-    const _id = `${guild!.id}-${command.commandName}`;
+		const _id = `${guild!.id}-${command.commandName}`;
 
-    if (!role) {
-      const document = await requiredroles.findById(_id);
+		if (!role) {
+			const document = await requiredroles.findById(_id);
 
-      const roles =
-        document && document.roles?.length
-          ? document.roles.map((roleId: string) => `<@&${roleId}>`)
-          : "None.";
+			const roles = document && document.roles?.length ? document.roles.map((roleId: string) => `<@&${roleId}>`) : "None.";
 
-      return {
-        content: `Here are the roles for "${commandName}": ${roles}`,
-        ephemeral: true,
-        allowedMentions: {
-          roles: [],
-        },
-      };
-    }
+			return {
+				content: `Here are the roles for "${commandName}": ${roles}`,
+				ephemeral: true,
+				allowedMentions: {
+					roles: [],
+				},
+			};
+		}
 
-    const alreadyExists = await requiredroles.findOne({
-      _id,
-      roles: {
-        $in: [role],
-      },
-    });
+		const alreadyExists = await requiredroles.findOne({
+			_id,
+			roles: {
+				$in: [role],
+			},
+		});
 
-    if (alreadyExists) {
-      await requiredroles.findOneAndUpdate(
-        {
-          _id,
-        },
-        {
-          _id,
-          $pull: {
-            roles: role,
-          },
-        }
-      );
+		if (alreadyExists) {
+			await requiredroles.findOneAndUpdate(
+				{
+					_id,
+				},
+				{
+					_id,
+					$pull: {
+						roles: role,
+					},
+				}
+			);
 
-      return {
-        content: `The command "${commandName}" no longer requires the role <@&${role}>`,
-        ephemeral: true,
-        allowedMentions: {
-          roles: [],
-        },
-      };
-    }
+			return {
+				content: `The command "${commandName}" no longer requires the role <@&${role}>`,
+				ephemeral: true,
+				allowedMentions: {
+					roles: [],
+				},
+			};
+		}
 
-    await requiredroles.findOneAndUpdate(
-      {
-        _id,
-      },
-      {
-        _id,
-        $addToSet: {
-          roles: role,
-        },
-      },
-      {
-        upsert: true,
-      }
-    );
+		await requiredroles.findOneAndUpdate(
+			{
+				_id,
+			},
+			{
+				_id,
+				$addToSet: {
+					roles: role,
+				},
+			},
+			{
+				upsert: true,
+			}
+		);
 
-    return {
-      content: `The command "${commandName}" now requires the role <@&${role}>`,
-      ephemeral: true,
-      allowedMentions: {
-        roles: [],
-      },
-    };
-  },
+		return {
+			content: `The command "${commandName}" now requires the role <@&${role}>`,
+			ephemeral: true,
+			allowedMentions: {
+				roles: [],
+			},
+		};
+	},
 } as CommandObject;


### PR DESCRIPTION
Currently, anyone can run the commands `/requiredroles` and `/channelcommand`. Added proper permission checks so that only Admins can run them (in line with the other built in commands).

Additionally, `/channelcommand` allowed for **any** channels to be selected as an option. Restricted it to only be `GuildText` channel types.
![image](https://user-images.githubusercontent.com/14950662/233125462-efce6b03-cad8-4df1-ac3a-d4f26113b988.png)
