### PR TITLE
defaultPrefix.

### DIFF
--- a/src/WOK.ts
+++ b/src/WOK.ts
@@ -18,6 +18,7 @@ class WOKCommands {
   private _commandHandler: CommandHandler | undefined
   private _eventHandler!: EventHandler
   private _isConnectedToDB = false
+  private _defaultPrefix = "!"
 
   constructor(options: Options) {
     this.init(options)
@@ -35,6 +36,7 @@ class WOKCommands {
       disabledDefaultCommands = [],
       events = {},
       validations = {},
+      defaultPrefix
     } = options
 
     if (!client) {
@@ -66,6 +68,10 @@ class WOKCommands {
       dbRequired: 300, // 5 minutes
       ...cooldownConfig,
     })
+
+    if (defaultPrefix) {
+      this._defaultPrefix = defaultPrefix
+    }
 
     if (commandsDir) {
       this._commandHandler = new CommandHandler(
@@ -120,6 +126,10 @@ class WOKCommands {
 
   public get isConnectedToDB(): boolean {
     return this._isConnectedToDB
+  }
+
+  public  get defaultPrefix(): string {
+    return this.defaultPrefix
   }
 
   private async connectToMongo(mongoUri: string) {

--- a/src/command-handler/PrefixHandler.ts
+++ b/src/command-handler/PrefixHandler.ts
@@ -4,12 +4,10 @@ import WOK from "../../typings";
 class PrefixHandler {
   // <guildId: prefix>
   private _prefixes = new Map();
-  private _defaultPrefix = "!";
   private _instance: WOK;
 
   constructor(instance: WOK) {
     this._instance = instance;
-
     this.loadPrefixes();
   }
 
@@ -26,7 +24,7 @@ class PrefixHandler {
   }
 
   public get defaultPrefix() {
-    return this._defaultPrefix;
+    return this._instance.defaultPrefix;
   }
 
   public get(guildId?: string) {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -24,6 +24,7 @@ export default class WOK {
   private _commandHandler: CommandHandler | undefined
   private _eventHandler!: EventHandler
   private _isConnectedToDB = false
+  private _defaultPrefix = "!"
 
   constructor(options: Options)
 
@@ -36,6 +37,7 @@ export default class WOK {
   public get commandHandler(): CommandHandler
   public get eventHandler(): EventHandler
   public get isConnectedToDB(): boolean
+  public get defaultPrefix(): string
 }
 
 export interface Options {
@@ -49,6 +51,7 @@ export interface Options {
   disabledDefaultCommands?: DefaultCommands[]
   events?: Events
   validations?: Validations
+  defaultPrefix?: string
 }
 
 export interface CooldownConfig {


### PR DESCRIPTION
## Introduction
Introducing a new feature called `defaultPrefix` which allows users to set a custom prefix for their bot. This feature is displayed as shown below:

![image](https://user-images.githubusercontent.com/123480557/236676383-7f03cc37-5dd8-410f-bd0e-965a2ac3c79d.png)

> Note: This feature is currently in a basic form and requires further enhancement. Before proceeding, it is imperative to determine whether the Handler even requires a feature like this. (I do have the entire plan btw.)

## Why is this needed?
A Major reason to introduce a feature like this would be the "How to change the prefix" forums/posts in the [WornOffKeys Server](https://discord.gg/xzjcQxEvSb).

## Problems
While the `defaultPrefix` feature is a valuable addition, it does come with certain drawbacks, such as:

- The potential for prefixes with spaces, for instance, "a b".
- The possibility of long prefixes, such as "AVeryVeryLongPrefixThatMayOrMayNotBeIntentional".
- Additional checks for Javascript users.

## Solution to the problem(s) 
### To handle prefix spaces:
- Fix: Give an Error
```typescript
if (defaultPrefix.includes(" ")) {
  throw new Error("Prefix may not contain spaces")
}
```

> Other Javascript checks would be provided in the next PR related to defaultPrefix

### To handle long prefix
- Fix: Trim the prefix.
```typescript
if (defaultPrefix.length >= 10) {
const NewPrefix = defaultPrefix.slice(0, 10)
console.log('⚠️ Prefix length exceeds 10 characters, the prefix provided has been trimmed to:', NewPrefix)
this._defaultPrefix = NewPrefix
}
```

## Outro
MERGE: 
![just-do-it-do-it](https://user-images.githubusercontent.com/123480557/236678484-b99946c0-5ce9-47a4-ad55-c5d8e0293891.gif)


