### PR TITLE
Small Addition for Autocomplete

### DIFF
--- a/src/event-handler/events/interactionCreate/isAutocomplete/autocomplete.ts
+++ b/src/event-handler/events/interactionCreate/isAutocomplete/autocomplete.ts
@@ -1,6 +1,6 @@
 import { AutocompleteInteraction } from "discord.js";
 
-import WOK from "../../../../../typings";
+import WOK, { AutocompleteChoice } from "../../../../../typings";
 
 export default async (interaction: AutocompleteInteraction, instance: WOK) => {
   const { commandHandler } = instance;
@@ -23,15 +23,16 @@ export default async (interaction: AutocompleteInteraction, instance: WOK) => {
   const choices = await autocomplete(command, focusedOption.name, interaction);
 
   const filtered = choices
-    .filter((choice: string) =>
-      choice.toLowerCase().startsWith(focusedOption.value.toLowerCase())
-    )
+    .filter((c: AutocompleteChoice) => {
+      const choice = c.name || c as string
+      return choice.toLowerCase().startsWith(focusedOption.value.toLowerCase())
+    })
     .slice(0, 25);
 
   await interaction.respond(
-    filtered.map((choice: string) => ({
-      name: choice,
-      value: choice,
+    filtered.map((choice: AutocompleteChoice) => ({
+      name: choice.name || choice,
+      value: choice.value || choice,
     }))
   );
 };

--- a/src/event-handler/events/interactionCreate/isAutocomplete/autocomplete.ts
+++ b/src/event-handler/events/interactionCreate/isAutocomplete/autocomplete.ts
@@ -23,9 +23,9 @@ export default async (interaction: AutocompleteInteraction, instance: WOK) => {
   const choices = await autocomplete(command, focusedOption.name, interaction);
 
   const filtered = choices
-    .filter((c: AutocompleteChoice) => {
-      const choice = c.name || c as string
-      return choice.toLowerCase().startsWith(focusedOption.value.toLowerCase())
+    .filter((choice: AutocompleteChoice) => {
+      const choiceName = choice.name || choice as string
+      return choiceName.toLowerCase().startsWith(focusedOption.value.toLowerCase())
     })
     .slice(0, 25);
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -131,6 +131,11 @@ export type FileData = {
   fileContents: any
 }
 
+export type AutocompleteChoice = {
+  name?: string,
+  value?: string,
+}
+
 export class Command {
   constructor(instance: WOK, commandName: string, commandObject: CommandObject)
 


### PR DESCRIPTION
## What's new?
> This change affects the autocomplete choices in the [command properties](https://docs.wornoffkeys.com/commands/autocomplete).

Created a new "AutocompleteChoice" type.
Added to the current method of just providing a string and now the ability to provide an object containing "name" and "value".

## Why the change?
This change allows the ability to provide different values for the choice's name and the choice's value. For example:
``` js
autocomplete: () => {
    return [
        { name: "Windows 10", value: "win-10" },
        { name: "Windows 11", value: "win-11" },
        { name: "Mac", value: "mac-os" },
        { name: "Linux", value: "linux" },
    ];
},
```

This change still supports the current method of autocomplete choices by just providing a string. For example:
``` js
autocomplete: () => {
    return ["Windows 10", "Windows 11", "Mac", "Linux"];
},
```