### PR TITLE
Update CommandHandler.ts

### DIFF
--- a/src/command-handler/CommandHandler.ts
+++ b/src/command-handler/CommandHandler.ts
@@ -219,7 +219,7 @@ class CommandHandler {
 
       const result = this._instance.cooldowns?.canRunAction(cooldownUsage)
 
-      if (typeof result === 'string') {
+      if (typeof result === 'string' && result !== "ERROR") {
         return result
       }
 


### PR DESCRIPTION
This change fixes a bug with the cooldowns map. I have only ran into it once but I tried to throw the error where the cooldown type is used outside of a guild with the user attached. It threw the error and tried to attach the expiry time of 7 minutes. When I have the dbRequired set to 5 minutes, it will try to input the info to mongo. Since it sent "ERROR" to the db, it also tried to input the time but it failed and sent a mongo error stating it could not insert a string to Date property.